### PR TITLE
Disable 'jump to next error' button when no errors

### DIFF
--- a/src/app/components/NodeList.tsx
+++ b/src/app/components/NodeList.tsx
@@ -119,6 +119,7 @@ function NodeList(props) {
             </button>
             <button
               className="button button--primary button--flex"
+              disabled={filteredErrorArray.length === 0}
               onClick={event => {
                 event.stopPropagation();
                 handleOpenFirstError();


### PR DESCRIPTION
Tiny nit... I noticed that the button doesn't become disabled when there are no errors in the selection.