### PR TITLE
Hide list item caret on frames with no children

### DIFF
--- a/src/app/components/ListItem.tsx
+++ b/src/app/components/ListItem.tsx
@@ -16,7 +16,7 @@ function ListItem(props) {
   }
 
   // The component calls itself if there are children
-  if (node.children) {
+  if (node.children && node.children.length) {
     // Find errors in this node's children.
     childErrorsCount = findNestedErrors(node);
 


### PR DESCRIPTION
Otherwise the caret will show up when you hover over a list item that has no children, such as this:

<img width="773" alt="Screen Shot 2020-02-29 at 11 17 40 AM" src="https://user-images.githubusercontent.com/1380747/75613674-4a5f6d80-5ae5-11ea-8660-260c42a312f9.png">
