### PR TITLE
Fix deduplication of different errors

### DIFF
--- a/src/app/components/BulkErrorList.tsx
+++ b/src/app/components/BulkErrorList.tsx
@@ -37,9 +37,9 @@ function BulkErrorList(props) {
 
     nodeErrors.forEach(error => {
       // Check to see if another error with this same value exists.
-      if (bulkErrorList.some(e => e.value === error.value)) {
+      if (bulkErrorList.some(e => e.type === error.type && e.message === error.message && e.value === error.value)) {
         // Find the error of this type that already exists.
-        let duplicateError = bulkErrorList.find(e => e.value === error.value);
+        let duplicateError = bulkErrorList.find(e => e.type === error.type && e.message === error.message && e.value === error.value);
         let nodesThatShareErrors = duplicateError.nodes;
         // Add the nodes id that share this error to the object
         // That way we can select them all at once.


### PR DESCRIPTION
The default `value` field of the object returned by `createErrorObject` is an empty string. Having two errors of different type or message share the value and comparison by value alone `"" === ""` is enough to merge two different errors into one.
```
createErrorObject(node, "new-kind", "Message 1")
createErrorObject(node, "new-kind", "Message 2")
```

With this change only errors with the same type, message and value are merged into one.