### PR TITLE
Remove some hard-coded paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-	"name": "figma-plugin-react-template",
-	"version": "1.0.0",
-	"description": "This plugin template uses Typescript. If you are familiar with Javascript, Typescript will look very familiar. In fact, valid Javascript code is already valid Typescript code.",
-	"license": "ISC",
-	"scripts": {
-		"build": "/usr/local/bin/node node_modules/.bin/webpack --mode=production",
-		"build:watch": "/usr/local/bin/node node_modules/.bin/webpack --mode=development --watch",
-		"prettier:format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,json}' "
-	},
-	"dependencies": {
-		"classnames": "^2.2.6",
-		"framer-motion": "^6.3.0",
-		"react": "^17.0.2",
-		"react-dom": "^17.0.2"
-	},
-	"devDependencies": {
-		"@figma/plugin-typings": "^1.54.0",
-		"@types/react": "^16.8.24",
-		"@types/react-dom": "^16.8.5",
-		"css-loader": "^3.1.0",
-		"html-webpack-inline-source-plugin": "^0.0.10",
-		"html-webpack-plugin": "^3.2.0",
-		"husky": "^3.0.2",
-		"lint-staged": "^9.2.1",
-		"prettier": "^1.18.2",
-		"style-loader": "^0.23.1",
-		"ts-loader": "^6.0.4",
-		"tslint": "^5.18.0",
-		"tslint-react": "^4.0.0",
-		"typescript": "^3.5.3",
-		"url-loader": "^2.1.0",
-		"webpack": "^4.39.1",
-		"webpack-cli": "^3.3.6"
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
-	},
-	"lint-staged": {
-		"src/**/*.{js,jsx,ts,tsx,css,json}": [
-			"prettier --write",
-			"git add"
-		]
-	}
+  "name": "figma-plugin-react-template",
+  "version": "1.0.0",
+  "description": "This plugin template uses Typescript. If you are familiar with Javascript, Typescript will look very familiar. In fact, valid Javascript code is already valid Typescript code.",
+  "license": "ISC",
+  "scripts": {
+    "build": "webpack --mode=production",
+    "build:watch": "webpack --mode=development --watch",
+    "prettier:format": "prettier --write 'src/**/*.{js,jsx,ts,tsx,css,json}' "
+  },
+  "dependencies": {
+    "classnames": "^2.2.6",
+    "framer-motion": "^6.3.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "@figma/plugin-typings": "^1.54.0",
+    "@types/react": "^16.8.24",
+    "@types/react-dom": "^16.8.5",
+    "css-loader": "^3.1.0",
+    "html-webpack-inline-source-plugin": "^0.0.10",
+    "html-webpack-plugin": "^3.2.0",
+    "husky": "^3.0.2",
+    "lint-staged": "^9.2.1",
+    "prettier": "^1.18.2",
+    "style-loader": "^0.23.1",
+    "ts-loader": "^6.0.4",
+    "tslint": "^5.18.0",
+    "tslint-react": "^4.0.0",
+    "typescript": "^3.5.3",
+    "url-loader": "^2.1.0",
+    "webpack": "^4.39.1",
+    "webpack-cli": "^3.3.6"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "src/**/*.{js,jsx,ts,tsx,css,json}": [
+      "prettier --write",
+      "git add"
+    ]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,6 @@
     "removeComments": true,
     "noImplicitAny": false,
     "moduleResolution": "node",
-    "typeRoots": [
-      "./node_modules/@types",
-      "./node_modules/@figma"
-    ]
+    "types": ["@figma/plugin-typings", "node", "react", "react-dom"]
   }
 }


### PR DESCRIPTION
When I tried cloning and building this locally in a monorepo, I noticed that some of the hard-coded paths were breaking. Hoping this will fix some things so that running  `yarn build` and `yarn build:watch` will work with a fresh clone