### PR TITLE
fix: postMessage of undefined values coming from clientStorage

### DIFF
--- a/src/plugin/controller.ts
+++ b/src/plugin/controller.ts
@@ -267,17 +267,21 @@ figma.ui.onmessage = msg => {
       });
 
       figma.clientStorage.getAsync("storedErrorsToIgnore").then(result => {
-        figma.ui.postMessage({
-          type: "fetched storage",
-          storage: result
-        });
+        if (result.length) {
+          figma.ui.postMessage({
+            type: "fetched storage",
+            storage: result
+          });
+        }
       });
 
       figma.clientStorage.getAsync("storedActivePage").then(result => {
-        figma.ui.postMessage({
-          type: "fetched active page",
-          storage: result
-        });
+        if (result.length) {
+          figma.ui.postMessage({
+            type: "fetched active page",
+            storage: result
+          });
+        }
       });
 
       figma.clientStorage.getAsync("storedRadiusValues").then(result => {


### PR DESCRIPTION
Hello. While using this plugin with my team we realised there are errors coming from `JSON.parse` on `undefined` values.

<img width="512" alt="image" src="https://user-images.githubusercontent.com/7059673/208897533-81f96072-2d48-47b9-a7ea-819edbfdbd2e.png">

<img width="513" alt="image" src="https://user-images.githubusercontent.com/7059673/208897624-726db62f-58e8-408c-971e-2b4b3f3b98fa.png">

I added a simple `if` check under `getAsync("storedErrorsToIgnore")` and `getAsync("storedActivePage")`, same as it is done for `getAsync("storedRadiusValues")`.
